### PR TITLE
feat - remove undeclared vars

### DIFF
--- a/src/api/contract/getAllWithdrawalBalances.js
+++ b/src/api/contract/getAllWithdrawalBalances.js
@@ -10,7 +10,7 @@ module.exports = async (dvf, starkTokenIds, tradingKey) => {
   const args = [starkTokenIds, tradingKey]
 
   try {
-    return (withdrawalBalance = await dvf.eth.call(
+    return (await dvf.eth.call(
       dvf.contract.abi.WithdrawalBalanceReader,
       dvf.config.DVF.registrationAndDepositInterfaceAddress,
       'allWithdrawalBalances',

--- a/src/api/contract/getAllWithdrawalBalancesEthAddress.js
+++ b/src/api/contract/getAllWithdrawalBalancesEthAddress.js
@@ -8,7 +8,7 @@ module.exports = async (dvf, starkTokenIds, address) => {
   const args = [starkTokenIds, address]
 
   try {
-    return (withdrawalBalance = await dvf.eth.call(
+    return (await dvf.eth.call(
       dvf.contract.abi.WithdrawalBalanceReader,
       dvf.config.DVF.registrationAndDepositInterfaceAddress,
       'allWithdrawalBalances',

--- a/src/api/contract/getWithdrawalBalance.js
+++ b/src/api/contract/getWithdrawalBalance.js
@@ -12,7 +12,7 @@ module.exports = async (dvf, token, tradingKey) => {
   const args = [tradingKey, starkTokenId]
 
   try {
-    return (withdrawalBalance = await dvf.eth.call(
+    return (await dvf.eth.call(
       dvf.contract.abi.getStarkEx(),
       dvf.config.DVF.starkExContractAddress,
       'getWithdrawalBalance',

--- a/src/api/contract/getWithdrawalBalanceEthAddress.js
+++ b/src/api/contract/getWithdrawalBalanceEthAddress.js
@@ -17,7 +17,7 @@ module.exports = async (dvf, token, address) => {
   const args = [address, starkTokenId]
 
   try {
-    return (withdrawalBalance = await dvf.eth.call(
+    return (await dvf.eth.call(
       dvf.contract.abi.getStarkEx(),
       dvf.config.DVF.starkExContractAddress,
       'getWithdrawalBalance',


### PR DESCRIPTION
In order to allow the Portal to migrate to Vite, we had to patch code in the @rhino.fi/client-js package. This is not ideal and we should really update client-js to fix these problems. This PR is to complete part of that work.

The following files need updating in @rhino.fi/client-js to allow these patches to be removed.

1. @rhino.fi/client-js/src/api/contract/getAllWithdrawalBalances.js 
2. @rhino.fi/client-js/src/api/contract/getAllWithdrawalBalancesEthAddress.js
3. @rhino.fi/client-js/src/api/contract/getWithdrawalBalance.js
4. @rhino.fi/client-js/src/api/contract/getWithdrawalBalanceEthAddress.js
 
All of the files above need the following code change to replace

`return (withdrawalBalance = await dvf.eth.call(`

with 

`return (await dvf.eth.call(`