### PR TITLE
feature - PI-390 - remove reference to ledger node-hid package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhino.fi/client-js",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "main": "src/index.js",
   "files": [
     "src",

--- a/src/lib/ledger/selectTransport.js
+++ b/src/lib/ledger/selectTransport.js
@@ -1,9 +1,4 @@
-module.exports = isBrowser => {
-  if (isBrowser) {
-    const Transport = require('@ledgerhq/hw-transport-webhid').default
-    return Transport
-  } else {
-    const Transport = require('@ledgerhq/hw-transport-node-hid').default
-    return Transport
-  }
+module.exports = () => {
+  const Transport = require('@ledgerhq/hw-transport-webhid').default
+  return Transport
 }


### PR DESCRIPTION
In order to allow the portal to migrate to Vite, we had to patch code in the @rhino.fi/client-js package. This is not ideal and we should really update client-js to fix these problems. This PR is to complete part of that work.

The following file has been updated in @rhino.fi/client-js to allow these patches to be removed.

@rhino.fi/client-js/src/lib/ledger/selectTransport.js